### PR TITLE
Add the systemd status for the remote agent

### DIFF
--- a/files/plugins/mk_systemd_status
+++ b/files/plugins/mk_systemd_status
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "<<<hcc_systemd>>>"
+systemctl show --property=Id,ActiveState '*' --no-pager
+

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -55,11 +55,11 @@ define check_mk::agent (
     }
 
     # copy plugins directory
-    file { "${plugin_active_location}":
+    file { $plugin_active_location:
         ensure  => directory,
         recurse => remote,
         mode    => '0755',
-        source  => 'puppet://modules/check_mk/plugins',
+        source  => 'puppet:///modules/check_mk/plugins',
     }
 
 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -54,11 +54,12 @@ define check_mk::agent (
         source  => 'puppet:///modules/check_mk/local_checks',
     }
 
-    # Copy systemd plugin
-    file { '${plugin_active_location}/mk_systemd_status':
-        ensure  => file,
+    # copy plugins directory
+    file { "${plugin_active_location}":
+        ensure  => directory,
+        recurse => remote,
         mode    => '0755',
-        source  => 'puppet://modules/check_mk/plugins/mk_systemd_status'
+        source  => 'puppet://modules/check_mk/plugins',
     }
 
 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -54,4 +54,11 @@ define check_mk::agent (
         source  => 'puppet:///modules/check_mk/local_checks',
     }
 
+    # Copy systemd plugin
+    file { '${plugin_active_location}/mk_systemd_status':
+        ensure  => file,
+        mode    => '0755',
+        source  => 'puppet://modules/check_mk/plugins/mk_systemd_status'
+    }
+
 }


### PR DESCRIPTION
In combination with this change, you also will need
the hcc_systemd python script to be run on the check_mk
node in order to intrepret the results.